### PR TITLE
Update for Trakt to use FanartHandler ClearArt paths for Movies

### DIFF
--- a/FanartHandler/FanartHandler.cs
+++ b/FanartHandler/FanartHandler.cs
@@ -810,6 +810,7 @@ namespace FanartHandler
                                      Utils.Check(FSelected.WindowsUsingFanartSelectedPictures.Count > 0) + " Pictures Fanart, " +
                                      Utils.Check(FSelected.WindowsUsingFanartSelectedScoreCenter.Count > 0) + " ScoreCenter Fanart");
         logger.Debug("           " + Utils.Check(FSelectedOther.WindowsUsingFanartSelectedClearArtMusic.Count > 0) + " Music ClearArt, " + 
+                                     Utils.Check(FSelectedOther.WindowsUsingFanartSelectedClearArtMovie.Count > 0) + " Movie ClearArt, " +
                                      Utils.Check(FSelectedOther.WindowsUsingFanartSelectedGenreMusic.Count > 0) + " Music Genres, " +
                                      Utils.Check(FSelectedOther.WindowsUsingFanartSelectedLabelMusic.Count > 0) + " Music Labels");
         logger.Debug("           " + Utils.Check(FSelectedOther.WindowsUsingFanartSelectedStudioMovie.Count > 0) + " Movie Studios, " + 
@@ -1643,6 +1644,7 @@ namespace FanartHandler
 
           var _flagClearArt = false;
           var _flagClearArtPlay = false;
+          var _flagClearArtMovies = false;
 
           var _flagLabelMusic = false;
           var _flagLabelPlay = false;
@@ -1666,7 +1668,7 @@ namespace FanartHandler
                                                            ref _flag1Movie, ref _flag2Movie, 
                                                            ref _flag1Picture, ref _flag2Picture, 
                                                            ref _flagPlay,
-                                                           ref _flagClearArt, ref _flagClearArtPlay,
+                                                           ref _flagClearArt, ref _flagClearArtPlay, ref _flagClearArtMovies,
                                                            ref _flagGenrePlay, ref _flagGenrePlaySingle, ref _flagGenrePlayAll, ref _flagGenrePlayVertical, 
                                                            ref _flagGenreMusic, ref _flagGenreMusicSingle, ref _flagGenreMusicAll, ref _flagGenreMusicVertical, 
                                                            ref _flagGenreMovie, ref _flagGenreMovieSingle, ref _flagGenreMovieAll, ref _flagGenreMovieVertical, 
@@ -1690,7 +1692,7 @@ namespace FanartHandler
                                                            ref _flag1Movie, ref _flag2Movie, 
                                                            ref _flag1Picture, ref _flag2Picture, 
                                                            ref _flagPlay, 
-                                                           ref _flagClearArt, ref _flagClearArtPlay,
+                                                           ref _flagClearArt, ref _flagClearArtPlay, ref _flagClearArtMovies,
                                                            ref _flagGenrePlay, ref _flagGenrePlaySingle, ref _flagGenrePlayAll, ref _flagGenrePlayVertical, 
                                                            ref _flagGenreMusic, ref _flagGenreMusicSingle, ref _flagGenreMusicAll, ref _flagGenreMusicVertical, 
                                                            ref _flagGenreMovie, ref _flagGenreMovieSingle, ref _flagGenreMovieAll, ref _flagGenreMovieVertical, 
@@ -1709,7 +1711,7 @@ namespace FanartHandler
                                                                ref _flag1Movie, ref _flag2Movie, 
                                                                ref _flag1Picture, ref _flag2Picture, 
                                                                ref _flagPlay, 
-                                                               ref _flagClearArt, ref _flagClearArtPlay,
+                                                               ref _flagClearArt, ref _flagClearArtPlay, ref _flagClearArtMovies,
                                                                ref _flagGenrePlay, ref _flagGenrePlaySingle, ref _flagGenrePlayAll, ref _flagGenrePlayVertical, 
                                                                ref _flagGenreMusic, ref _flagGenreMusicSingle, ref _flagGenreMusicAll, ref _flagGenreMusicVertical, 
                                                                ref _flagGenreMovie, ref _flagGenreMovieSingle, ref _flagGenreMovieAll, ref _flagGenreMovieVertical, 
@@ -1730,7 +1732,7 @@ namespace FanartHandler
                                                              ref _flag1Movie, ref _flag2Movie, 
                                                              ref _flag1Picture, ref _flag2Picture, 
                                                              ref _flagPlay, 
-                                                             ref _flagClearArt, ref _flagClearArtPlay,
+                                                             ref _flagClearArt, ref _flagClearArtPlay, ref _flagClearArtMovies,
                                                              ref _flagGenrePlay, ref _flagGenrePlaySingle, ref _flagGenrePlayAll, ref _flagGenrePlayVertical, 
                                                              ref _flagGenreMusic, ref _flagGenreMusicSingle, ref _flagGenreMusicAll, ref _flagGenreMusicVertical, 
                                                              ref _flagGenreMovie, ref _flagGenreMovieSingle, ref _flagGenreMovieAll, ref _flagGenreMovieVertical, 
@@ -1759,7 +1761,7 @@ namespace FanartHandler
                                                            ref _flag1Movie, ref _flag2Movie, 
                                                            ref _flag1Picture, ref _flag2Picture, 
                                                            ref _flagPlay, 
-                                                           ref _flagClearArt, ref _flagClearArtPlay,
+                                                           ref _flagClearArt, ref _flagClearArtPlay, ref _flagClearArtMovies,
                                                            ref _flagGenrePlay, ref _flagGenrePlaySingle, ref _flagGenrePlayAll, ref _flagGenrePlayVertical, 
                                                            ref _flagGenreMusic, ref _flagGenreMusicSingle, ref _flagGenreMusicAll, ref _flagGenreMusicVertical, 
                                                            ref _flagGenreMovie, ref _flagGenreMovieSingle, ref _flagGenreMovieAll, ref _flagGenreMovieVertical, 
@@ -1778,7 +1780,7 @@ namespace FanartHandler
                                                                ref _flag1Movie, ref _flag2Movie, 
                                                                ref _flag1Picture, ref _flag2Picture, 
                                                                ref _flagPlay, 
-                                                               ref _flagClearArt, ref _flagClearArtPlay,
+                                                               ref _flagClearArt, ref _flagClearArtPlay, ref _flagClearArtMovies,
                                                                ref _flagGenrePlay, ref _flagGenrePlaySingle, ref _flagGenrePlayAll, ref _flagGenrePlayVertical, 
                                                                ref _flagGenreMusic, ref _flagGenreMusicSingle, ref _flagGenreMusicAll, ref _flagGenreMusicVertical, 
                                                                ref _flagGenreMovie, ref _flagGenreMovieSingle, ref _flagGenreMovieAll, ref _flagGenreMovieVertical, 
@@ -1799,7 +1801,7 @@ namespace FanartHandler
                                                              ref _flag1Movie, ref _flag2Movie, 
                                                              ref _flag1Picture, ref _flag2Picture, 
                                                              ref _flagPlay, 
-                                                             ref _flagClearArt, ref _flagClearArtPlay,
+                                                             ref _flagClearArt, ref _flagClearArtPlay, ref _flagClearArtMovies,
                                                              ref _flagGenrePlay, ref _flagGenrePlaySingle, ref _flagGenrePlayAll, ref _flagGenrePlayVertical, 
                                                              ref _flagGenreMusic, ref _flagGenreMusicSingle, ref _flagGenreMusicAll, ref _flagGenreMusicVertical, 
                                                              ref _flagGenreMovie, ref _flagGenreMovieSingle, ref _flagGenreMovieAll, ref _flagGenreMovieVertical, 
@@ -1847,6 +1849,11 @@ namespace FanartHandler
             if (_flagClearArt && !Utils.ContainsID(FSelectedOther.WindowsUsingFanartSelectedClearArtMusic, nodeValue))
             {
               FSelectedOther.WindowsUsingFanartSelectedClearArtMusic.Add(nodeValue, nodeValue);
+            }
+            // Selected Movie ClearArt
+            if (_flagClearArtMovies && !Utils.ContainsID(FSelectedOther.WindowsUsingFanartSelectedClearArtMovie, nodeValue))
+            {
+              FSelectedOther.WindowsUsingFanartSelectedClearArtMovie.Add(nodeValue, nodeValue);
             }
             #endregion
 
@@ -2047,7 +2054,7 @@ namespace FanartHandler
                                   ref bool _flag1Movie, ref bool _flag2Movie,
                                   ref bool _flag1Picture, ref bool _flag2Picture, 
                                   ref bool _flagPlay, 
-                                  ref bool _flagClearArt, ref bool _flagClearArtPlay,   
+                                  ref bool _flagClearArt, ref bool _flagClearArtPlay, ref bool _flagClearArtMovies,
                                   ref bool _flagGenrePlay, ref bool _flagGenrePlaySingle, ref bool _flagGenrePlayAll, ref bool _flagGenrePlayVertical, 
                                   ref bool _flagGenreMusic, ref bool _flagGenreMusicSingle, ref bool _flagGenreMusicAll, ref bool _flagGenreMusicVertical, 
                                   ref bool _flagGenreMovie, ref bool _flagGenreMovieSingle, ref bool _flagGenreMovieAll, ref bool _flagGenreMovieVertical, 
@@ -2134,6 +2141,12 @@ namespace FanartHandler
       if (_xml.Contains("#fanarthandler.music.artistclearart.selected") || _xml.Contains("#fanarthandler.music.artistbanner.selected") || _xml.Contains("#fanarthandler.music.albumcd.selected"))
       {
         _flagClearArt = true;
+      }
+
+      // ClearArt Movies
+      if (_xml.Contains("#fanarthandler.movie.clearart.selected") || _xml.Contains("#fanarthandler.movie.clearlogo.selected") || _xml.Contains("#fanarthandler.movie.cd.selected") || _xml.Contains("#fanarthandler.series.clearart.selected") || _xml.Contains("#fanarthandler.series.clearlogo.selected"))
+      {
+        _flagClearArtMovies = true;
       }
 
       // Labels

--- a/FanartHandler/FanartSelectedOther.cs
+++ b/FanartHandler/FanartSelectedOther.cs
@@ -147,6 +147,7 @@ namespace FanartHandler
               if (!string.IsNullOrEmpty(selectedTitle))
               {
                 SelectedItem = selectedTitle;
+                Utils.SetProperty("#Trakt.Movie.ImdbId","");
               }
             }
             AddSelectedGenreProperty(SelectedGenre, SelectedItem, property);

--- a/FanartHandler/FanartSelectedOther.cs
+++ b/FanartHandler/FanartSelectedOther.cs
@@ -159,6 +159,7 @@ namespace FanartHandler
                 SelectedItem.StartsWith("Previous ") && SelectedItem.EndsWith(" Days"))
             {
               IsSelectedVideo = true;
+              Utils.SetProperty("#Trakt.Movie.ImdbId","");
             }
 
             if (isVideo)

--- a/FanartHandler/FanartSelectedOther.cs
+++ b/FanartHandler/FanartSelectedOther.cs
@@ -157,7 +157,6 @@ namespace FanartHandler
 
             if (isVideo)
             {
-                Console.WriteLine(Utils.iActiveWindow.ToString());
                 AddSelectedMoviePropertys();
             }
 
@@ -855,10 +854,21 @@ namespace FanartHandler
       {
         strIMDBID = Utils.GetProperty("#myfilms.db.imdb_id.value");
       }
+
+      var window = GUIWindowManager.GetWindow(Utils.iActiveWindow);
+      GUIListItem selectedListItem = null;
+      if (window != null)
+      {
+        selectedListItem = GUIControl.GetSelectedListItem(Utils.iActiveWindow, window.GetFocusControlId());
+        if (selectedListItem == null && string.IsNullOrEmpty(strIMDBID))
+          return;
+      }
+
       if (string.IsNullOrEmpty(strIMDBID))
       {
         strIMDBID = Utils.GetProperty("#Trakt.Movie.ImdbId");
       }
+
       string strTVDBID = Utils.GetProperty("#Trakt.Show.TvdbId");
       if (string.IsNullOrEmpty(strTVDBID))
       {
@@ -867,18 +877,13 @@ namespace FanartHandler
       if (string.IsNullOrEmpty(strTVDBID))
       {
         // TV Series ID
-        var window = GUIWindowManager.GetWindow(Utils.iActiveWindow);
-        if (window != null)
+        if (selectedListItem != null)
         {
-            var selectedListItem = GUIControl.GetSelectedListItem(Utils.iActiveWindow, window.GetFocusControlId());
-            if (selectedListItem != null)
-            {
-                DBSeries series = selectedListItem.TVTag as DBSeries;
-                if (series != null)
-                {
-                    strTVDBID = series[DBOnlineSeries.cID];
-                }
-            }
+          DBSeries series = selectedListItem.TVTag as DBSeries;
+          if (series != null)
+          {
+            strTVDBID = series[DBOnlineSeries.cID];
+          }
         }
       }
 

--- a/FanartHandler/FanartSelectedOther.cs
+++ b/FanartHandler/FanartSelectedOther.cs
@@ -151,6 +151,15 @@ namespace FanartHandler
             }
             AddSelectedGenreProperty(SelectedGenre, SelectedItem, property);
 
+            // Trakt remove ClearArt for pages
+            if (SelectedItem == "Next Page" ||
+                SelectedItem == "Previous Page" ||
+                SelectedItem.StartsWith("Next ") && SelectedItem.EndsWith(" Days") ||
+                SelectedItem.StartsWith("Previous ") && SelectedItem.EndsWith(" Days"))
+            {
+              IsSelectedVideo = true;
+            }
+
             if (isVideo)
             {
               AddSelectedMoviePropertys();
@@ -304,6 +313,15 @@ namespace FanartHandler
               Utils.ContainsID(WindowsUsingFanartSelectedAwardMovie))
           {
             IsSelectedVideo = true;
+            if (Utils.iActiveWindow == 87266 || // Trakt Trending Movies
+                Utils.iActiveWindow == 87700 || // Trakt Calendar Movies
+                Utils.iActiveWindow == 87101 || // Trakt Popular Movies
+                Utils.iActiveWindow == 87263 || // Trakt Recommendations Movies
+                Utils.iActiveWindow == 87605 || // Trakt Anticipated Movies
+                Utils.iActiveWindow == 87607) // Trakt Box Office
+            {
+                IsSelectedVideo = false;
+            }
             RefreshGenericSelectedProperties(Utils.SelectedType.Movie, 
                                              ref CurrSelectedMovie, 
                                              ref CurrSelectedMovieTitle);
@@ -848,6 +866,10 @@ namespace FanartHandler
       if (string.IsNullOrEmpty(strIMDBID))
       {
         strIMDBID = Utils.GetProperty("#myfilms.db.imdb_id.value");
+      }
+      if (string.IsNullOrEmpty(strIMDBID))
+      {
+        strIMDBID = Utils.GetProperty("#Trakt.Movie.ImdbId");
       }
 
       if (!string.IsNullOrEmpty(strIMDBID))

--- a/FanartHandler/FanartSelectedOther.cs
+++ b/FanartHandler/FanartSelectedOther.cs
@@ -152,18 +152,25 @@ namespace FanartHandler
             AddSelectedGenreProperty(SelectedGenre, SelectedItem, property);
 
             // Trakt remove ClearArt for pages
-            if (SelectedItem == "Next Page" ||
-                SelectedItem == "Previous Page" ||
-                SelectedItem.StartsWith("Next ") && SelectedItem.EndsWith(" Days") ||
-                SelectedItem.StartsWith("Previous ") && SelectedItem.EndsWith(" Days"))
+            var window = GUIWindowManager.GetWindow(Utils.iActiveWindow);
+            if (window != null)
             {
-              IsSelectedVideo = true;
-              Utils.SetProperty("#Trakt.Movie.ImdbId","");
-            }
-
-            if (isVideo)
-            {
-              AddSelectedMoviePropertys();
+                var selectedListItem = GUIControl.GetSelectedListItem(Utils.iActiveWindow, window.GetFocusControlId());
+                if (selectedListItem != null)
+                {
+                    if (selectedListItem.IsFolder)
+                    {
+                        IsSelectedVideo = true;
+                        ClearSelectedMoviePropertys();
+                    }
+                    else
+                    {
+                        if (isVideo)
+                        {
+                            AddSelectedMoviePropertys();
+                        }
+                    }
+                }
             }
 
             ResetRefreshTickCount();
@@ -319,7 +326,14 @@ namespace FanartHandler
                 Utils.iActiveWindow == 87101 || // Trakt Popular Movies
                 Utils.iActiveWindow == 87263 || // Trakt Recommendations Movies
                 Utils.iActiveWindow == 87605 || // Trakt Anticipated Movies
-                Utils.iActiveWindow == 87607) // Trakt Box Office
+                Utils.iActiveWindow == 87607 || // Trakt Box Office
+                Utils.iActiveWindow == 87265 || // Trakt Trending Series
+                Utils.iActiveWindow == 87102 || // Trakt Popular Series
+                Utils.iActiveWindow == 87262 || // Trakt Recommendations Series
+                Utils.iActiveWindow == 87259 || // Trakt Calendar Series
+                Utils.iActiveWindow == 87606 || // Trakt Anticipated Series
+                Utils.iActiveWindow == 87281 || // Trakt Series Seasons
+                Utils.iActiveWindow == 87282) // Trakt Series Episodes
             {
                 IsSelectedVideo = false;
             }
@@ -872,6 +886,11 @@ namespace FanartHandler
       {
         strIMDBID = Utils.GetProperty("#Trakt.Movie.ImdbId");
       }
+      string strTVDBID = Utils.GetProperty("#Trakt.Show.TvdbId");
+      if (string.IsNullOrEmpty(strTVDBID))
+      {
+        strTVDBID = Utils.GetProperty("#TVSeries.Series.ID");
+      }
 
       if (!string.IsNullOrEmpty(strIMDBID))
       {
@@ -889,7 +908,14 @@ namespace FanartHandler
         Utils.SetProperty("movie.cd.selected", 
                            Utils.FanartTVFileExists(strIMDBID, null, null, Utils.FanartTV.MoviesCDArt) ? Utils.GetFanartTVFileName(strIMDBID, null, null, Utils.FanartTV.MoviesCDArt) : string.Empty);
       }
-      else
+      if (!string.IsNullOrEmpty(strTVDBID))
+      {
+        Utils.SetProperty("series.clearart.selected",
+                           Utils.FanartTVFileExists(strTVDBID, null, null, Utils.FanartTV.SeriesClearArt) ? Utils.GetFanartTVFileName(strTVDBID, null, null, Utils.FanartTV.SeriesClearArt) : string.Empty);
+        Utils.SetProperty("series.clearlogo.selected",
+                           Utils.FanartTVFileExists(strTVDBID, null, null, Utils.FanartTV.SeriesClearLogo) ? Utils.GetFanartTVFileName(strTVDBID, null, null, Utils.FanartTV.SeriesClearLogo) : string.Empty);
+      }
+      if (string.IsNullOrEmpty(strIMDBID) && string.IsNullOrEmpty(strTVDBID))
       {
         ClearSelectedMoviePropertys();
       }
@@ -903,6 +929,9 @@ namespace FanartHandler
       Utils.SetProperty("movie.clearlogo.selected", string.Empty);
       Utils.SetProperty("movie.banner.selected", string.Empty);
       Utils.SetProperty("movie.cd.selected", string.Empty);
+
+      Utils.SetProperty("series.clearart.selected", string.Empty);
+      Utils.SetProperty("series.clearlogo.selected", string.Empty);
     }
 
     private void EmptyMusicProperties(bool currClean = true)

--- a/FanartHandler/FanartSelectedOther.cs
+++ b/FanartHandler/FanartSelectedOther.cs
@@ -147,7 +147,6 @@ namespace FanartHandler
               if (!string.IsNullOrEmpty(selectedTitle))
               {
                 SelectedItem = selectedTitle;
-                Utils.SetProperty("#Trakt.Movie.ImdbId","");
               }
             }
             AddSelectedGenreProperty(SelectedGenre, SelectedItem, property);

--- a/FanartHandler/FanartSelectedOther.cs
+++ b/FanartHandler/FanartSelectedOther.cs
@@ -13,7 +13,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using WindowPlugins.GUITVSeries;
 
 namespace FanartHandler
 {
@@ -157,7 +156,7 @@ namespace FanartHandler
 
             if (isVideo)
             {
-                AddSelectedMoviePropertys();
+              AddSelectedMoviePropertys(SelectedItem);
             }
 
             ResetRefreshTickCount();
@@ -843,7 +842,7 @@ namespace FanartHandler
       FanartAvailable = FanartAvailable || picFound;
     }
     
-    public void AddSelectedMoviePropertys()
+    public void AddSelectedMoviePropertys(string SelectedItem)
     {
       string strIMDBID = Utils.GetProperty("#imdbnumber");
       if (string.IsNullOrEmpty(strIMDBID))
@@ -855,14 +854,9 @@ namespace FanartHandler
         strIMDBID = Utils.GetProperty("#myfilms.db.imdb_id.value");
       }
 
-      var window = GUIWindowManager.GetWindow(Utils.iActiveWindow);
-      GUIListItem selectedListItem = null;
-      if (window != null)
-      {
-        selectedListItem = GUIControl.GetSelectedListItem(Utils.iActiveWindow, window.GetFocusControlId());
-        if (selectedListItem == null && string.IsNullOrEmpty(strIMDBID))
-          return;
-      }
+      // Trakt does not clear the #Trakt.Movie.ImdbId value so exit function when Trakt page and SelectedItem is null, or ClearArt will turn up when it should not
+      if (SelectedItem == "TraktIsNull")
+        return;
 
       if (string.IsNullOrEmpty(strIMDBID))
       {
@@ -874,18 +868,11 @@ namespace FanartHandler
       {
         strTVDBID = Utils.GetProperty("#TVSeries.Series.ID");
       }
-      if (string.IsNullOrEmpty(strTVDBID))
-      {
-        // TV Series ID
-        if (selectedListItem != null)
-        {
-          DBSeries series = selectedListItem.TVTag as DBSeries;
-          if (series != null)
-          {
-            strTVDBID = series[DBOnlineSeries.cID];
-          }
-        }
-      }
+      //if (string.IsNullOrEmpty(strTVDBID))
+      //{
+      //  // TV Series ID
+      //  strTVDBID = UtilsTVSeries.GetTVSeriesID(50);
+      //}
 
       if (!string.IsNullOrEmpty(strIMDBID))
       {

--- a/FanartHandler/Utils.cs
+++ b/FanartHandler/Utils.cs
@@ -2654,9 +2654,16 @@ namespace FanartHandler
             if (window != null)
             {
                 var selectedListItem = GUIControl.GetSelectedListItem(Utils.iActiveWindow, window.GetFocusControlId());
-                if (selectedListItem == null || selectedListItem.IsFolder)
+                if (selectedListItem != null)
                 {
-                    SelectedItem = string.Empty;
+                    if (selectedListItem.IsFolder)
+                    {
+                        GUIControl cntl = window.GetControl(50);
+                        if (cntl is GUIFacadeControl)
+                        {
+                            SelectedItem = string.Empty;
+                        }
+                    }
                 }
             }
         }

--- a/FanartHandler/Utils.cs
+++ b/FanartHandler/Utils.cs
@@ -823,7 +823,13 @@ namespace FanartHandler
       {
         MoviesClearArtFolder = Path.Combine(MPThumbsFolder, @"Movies\ClearArt\FullSize\"); // DVDArt
         if (!Directory.Exists(MoviesClearArtFolder) || IsDirectoryEmpty(MoviesClearArtFolder))
-          MoviesClearArtFolder = string.Empty;
+        {
+          MoviesClearArtFolder = Path.Combine(MPThumbsFolder, @"MovingPictures\ClearArt\FullSize\"); // Moving Pictures
+          if (!Directory.Exists(MoviesClearArtFolder) || IsDirectoryEmpty(MoviesClearArtFolder))
+          {
+            MoviesClearArtFolder = string.Empty;
+          }
+        }
       }
       if (!string.IsNullOrEmpty(MoviesClearArtFolder))
       {
@@ -847,7 +853,13 @@ namespace FanartHandler
       {
         MoviesCDArtFolder = Path.Combine(MPThumbsFolder, @"Movies\DVDArt\FullSize\"); // DVDArt
         if (!Directory.Exists(MoviesCDArtFolder) || IsDirectoryEmpty(MoviesCDArtFolder))
-          MoviesCDArtFolder = string.Empty;
+        {
+          MoviesCDArtFolder = Path.Combine(MPThumbsFolder, @"MovingPictures\DVDArt\FullSize\"); // Moving Pictures
+          if (!Directory.Exists(MoviesCDArtFolder) || IsDirectoryEmpty(MoviesCDArtFolder))
+          {
+            MoviesCDArtFolder = string.Empty;
+          }
+        }
       }
       if (!string.IsNullOrEmpty(MoviesCDArtFolder))
       {
@@ -859,7 +871,13 @@ namespace FanartHandler
       {
         MoviesClearLogoFolder = Path.Combine(MPThumbsFolder, @"Movies\ClearLogo\FullSize\"); // DVDArt
         if (!Directory.Exists(MoviesClearLogoFolder) || IsDirectoryEmpty(MoviesClearLogoFolder))
-          MoviesClearLogoFolder = string.Empty;
+        {
+          MoviesClearLogoFolder = Path.Combine(MPThumbsFolder, @"MovingPictures\ClearLogo\FullSize\"); // Moving Pictures
+          if (!Directory.Exists(MoviesClearLogoFolder) || IsDirectoryEmpty(MoviesClearLogoFolder))
+          {
+            MoviesClearLogoFolder = string.Empty;
+          }
+        }
       }
       if (!string.IsNullOrEmpty(MoviesClearLogoFolder))
       {

--- a/FanartHandler/Utils.cs
+++ b/FanartHandler/Utils.cs
@@ -2634,6 +2634,32 @@ namespace FanartHandler
           }
           catch { }
         }
+        else if (iActiveWindow == 87266 || // Trakt Trending Movies
+                iActiveWindow == 87700 || // Trakt Calendar Movies
+                iActiveWindow == 87101 || // Trakt Popular Movies
+                iActiveWindow == 87263 || // Trakt Recommendations Movies
+                iActiveWindow == 87605 || // Trakt Anticipated Movies
+                iActiveWindow == 87607 || // Trakt Box Office
+                iActiveWindow == 87265 || // Trakt Trending Series
+                iActiveWindow == 87102 || // Trakt Popular Series
+                iActiveWindow == 87262 || // Trakt Recommendations Series
+                iActiveWindow == 87259 || // Trakt Calendar Series
+                iActiveWindow == 87606 || // Trakt Anticipated Series
+                iActiveWindow == 87281 || // Trakt Series Seasons
+                iActiveWindow == 87282) // Trakt Series Episodes
+        {
+            SelectedItem = Utils.GetProperty("#selecteditem");
+            // Remove ClearArt on Trakt Folders
+            var window = GUIWindowManager.GetWindow(Utils.iActiveWindow);
+            if (window != null)
+            {
+                var selectedListItem = GUIControl.GetSelectedListItem(Utils.iActiveWindow, window.GetFocusControlId());
+                if (selectedListItem == null || selectedListItem.IsFolder)
+                {
+                    SelectedItem = string.Empty;
+                }
+            }
+        }
         else
           SelectedItem = Utils.GetProperty("#selecteditem");
 

--- a/FanartHandler/Utils.cs
+++ b/FanartHandler/Utils.cs
@@ -2666,24 +2666,29 @@ namespace FanartHandler
                 iActiveWindow == 87281 || // Trakt Series Seasons
                 iActiveWindow == 87282) // Trakt Series Episodes
         {
-            SelectedItem = Utils.GetProperty("#selecteditem");
-            // Remove ClearArt on Trakt Folders
-            var window = GUIWindowManager.GetWindow(Utils.iActiveWindow);
-            if (window != null)
+          SelectedItem = Utils.GetProperty("#selecteditem");
+          // Remove ClearArt on Trakt Folders
+          var window = GUIWindowManager.GetWindow(Utils.iActiveWindow);
+          if (window != null)
+          {
+            var selectedListItem = GUIControl.GetSelectedListItem(Utils.iActiveWindow, window.GetFocusControlId());
+            if (selectedListItem != null) // (selectedListItem != null || selectedListItem.IsFolder)
             {
-                var selectedListItem = GUIControl.GetSelectedListItem(Utils.iActiveWindow, window.GetFocusControlId());
-                if (selectedListItem != null)
+              if (selectedListItem.IsFolder)
                 {
-                    if (selectedListItem.IsFolder)
-                    {
-                        GUIControl cntl = window.GetControl(50);
-                        if (cntl is GUIFacadeControl)
-                        {
-                            SelectedItem = string.Empty;
-                        }
-                    }
+                  GUIControl cntl = window.GetControl(50);
+                  if (cntl is GUIFacadeControl)
+                  {
+                    SelectedItem = string.Empty;
+                  }
                 }
             }
+            else
+            {
+              // Trakt menu is a null SelectedItem but we dont want to clear the SelectedItem when a movie is selected
+              SelectedItem = "TraktIsNull";
+            }
+          }
         }
         else
           SelectedItem = Utils.GetProperty("#selecteditem");

--- a/FanartHandler/Utils.cs
+++ b/FanartHandler/Utils.cs
@@ -2568,7 +2568,7 @@ namespace FanartHandler
         }
         else if (iActiveWindow == 96742)     // Moving Pictures
         {
-          SelectedItem = Utils.GetProperty("#selecteditem");
+          SelectedItem = Utils.GetProperty("#MovingPictures.SelectedMovie.title");
           SelectedStudios = Utils.GetProperty("#MovingPictures.SelectedMovie.studios");
           SelectedGenre = Utils.GetProperty("#MovingPictures.SelectedMovie.genres");
           // logger.Debug("*** "+SelectedItem+" - "+SelectedStudios+" - "+SelectedGenre);

--- a/FanartHandler/UtilsTVSeries.cs
+++ b/FanartHandler/UtilsTVSeries.cs
@@ -209,6 +209,34 @@ namespace FanartHandler
       return result;
     }
 
+    internal static string GetTVSeriesID(int ControlID)  // -> TV Series ID ...
+    {
+      if (!Utils.TVSeriesEnabled)
+      {
+        return string.Empty;
+      }
+      if (Utils.iActiveWindow != 9811 &&    // TVSeries
+          Utils.iActiveWindow != 9813)      // TVSeries Playlist
+      {
+        return string.Empty;
+      }
+      var window = GUIWindowManager.GetWindow(Utils.iActiveWindow);
+      GUIControl cntl = window.GetControl(50);
+      if (cntl != null && cntl is GUIFacadeControl)
+      {
+         GUIListItem selectedListItem = (cntl as GUIFacadeControl).SelectedListItem;
+         if (selectedListItem != null)
+         {
+           DBSeries series = selectedListItem.TVTag as DBSeries;
+           if (series != null)
+           {
+             return series[DBOnlineSeries.cID];
+           }
+         }
+      }
+        return string.Empty;
+    }
+
     internal static string GetTVSeriesAttributes(GUIListItem currentitem, ref string sGenre, ref string sStudio) // -> TV Series name ...
     {
       if (!Utils.TVSeriesEnabled)


### PR DESCRIPTION
Utils update to allow MovingPictures to display ClearArt when opened through Trakt Movie categories.

FanartSelectedOther updates:
Aadd IMDBID for Trakt.
Change IsSelectedVideo to false for Trakt movie pages so the ClearArt images don't clear after a movie is selected.
Clear ClearArt images when page navigation selected in Trakt.

This requires MePo update to work.